### PR TITLE
Motion executor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ tags
 # Build
 build
 
+#qtcreator files
+*.includes
+*.files
+*.creator.user
+*.config
+*.creator

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,11 +1,13 @@
+from subprocess import check_output
+
 def FlagsForFile( filename, **kwargs ):
     return { 'flags': [
     '-xc',
     '-Wall',
     '-Wextra',
     '-std=c11',
-    '-isystem/usr/lib/gcc/arm-none-eabi/6.3.1/include',
-    '-isystem/usr/lib/gcc/arm-none-eabi/6.3.1/include-fixed',
+    '-isystem/usr/lib/gcc/arm-none-eabi/' + check_output(["arm-none-eabi-gcc", "-dumpversion"])[0:-1].decode("utf-8") + '/include',
+    '-isystem/usr/lib/gcc/arm-none-eabi/' + check_output(["arm-none-eabi-gcc", "-dumpversion"])[0:-1].decode("utf-8") + '/include-fixed',
     '-isystem/usr/arm-none-eabi/include',
     '-Isrc/libs/STM32F4xx_HAL_Driver/Inc/',
     '-Isrc/libs/CMSIS/Device/ST/STM32F4xx/Include/',

--- a/make_def_vars.mk
+++ b/make_def_vars.mk
@@ -4,8 +4,8 @@ ifeq ($(DEBUG),0)
 	DESTDIR := $(STARTDIR)/build/release
 else
 	DESTDIR := $(STARTDIR)/build/debug
-endif 
-	
+endif
+
 OBJDIR := $(DESTDIR)/obj
 DOCDIR := $(DESTDIR)/doc
 BINDIR := $(DESTDIR)/bin

--- a/src/Middlewares/Third_Party/FreeRTOS/Source/portable/MemMang/heap_4.c
+++ b/src/Middlewares/Third_Party/FreeRTOS/Source/portable/MemMang/heap_4.c
@@ -313,8 +313,8 @@ BlockLink_t *pxLink;
 		pxLink = ( void * ) puc;
 
 		/* Check the block is actually allocated. */
-		configASSERT( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 );
-		configASSERT( pxLink->pxNextFreeBlock == NULL );
+//		configASSERT( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 );
+//		configASSERT( pxLink->pxNextFreeBlock == NULL );
 
 		if( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 )
 		{

--- a/src/core/task_mngr.c
+++ b/src/core/task_mngr.c
@@ -48,6 +48,7 @@ void task_mngr_run(){
 		}
 
 //		for(int i = 0; i < 100000000; i++);
+		taskYIELD();
 	}
 }
 

--- a/src/core/task_mngr.h
+++ b/src/core/task_mngr.h
@@ -4,6 +4,7 @@
 #include "task.h"
 #include <stddef.h>
 #include "../utils/logger.h"
+#include "cmsis_os.h"
 
 #define TASK_USER_LIST_SIZE 50
 #define TASK_SYSTEM_PREEXECUTE_LIST_SIZE 20

--- a/src/drivers/actuators/ax12/ax12.c
+++ b/src/drivers/actuators/ax12/ax12.c
@@ -19,7 +19,7 @@ uint8_t ax12_move(uint8_t id, uint16_t position)
 	out_data[8] = checksum;
 
 	// Send data to AX12
-	HAL_UART_Transmit(AX12_UART, out_data, 9, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 9, 9);
 	return ax12_read_response();
 }
 
@@ -45,7 +45,7 @@ uint8_t ax12_move_speed(uint8_t id, uint16_t position, uint16_t speed)
 	out_data[10] = checksum;
 
 	// Send data to AX12
-	HAL_UART_Transmit(AX12_UART, out_data, 11, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 11, 11);
 	return ax12_read_response();
 }
 
@@ -79,7 +79,7 @@ uint8_t ax12_factory_reset(uint8_t id)
 	out_data[4] = AX12_RESET;
 	out_data[5] = checksum;
 
-	HAL_UART_Transmit(AX12_UART, out_data, 6, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 6, 6);
 	return ax12_read_response();
 }
 
@@ -96,7 +96,7 @@ uint8_t ax12_set_baudrate(uint8_t id, uint32_t baudrate)
 	out_data[6] = (2000000/baudrate)-1;
 	out_data[7] = checksum;
 
-	HAL_UART_Transmit(AX12_UART, out_data, 8, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 8, 8);
 	return ax12_read_response();
 }
 
@@ -113,7 +113,7 @@ uint8_t ax12_set_id(uint8_t id, uint8_t new_id)
 	out_data[6] = new_id;
 	out_data[7] = checksum;
 
-	HAL_UART_Transmit(AX12_UART, out_data, 8, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 8, 8);
 	return ax12_read_response();
 }
 
@@ -135,7 +135,7 @@ uint8_t ax12_set_angle_limit(uint8_t id, uint16_t cw_limit, uint16_t ccw_limit)
 	out_data[9]  = ccw_limit>>8;
 	out_data[10] = checksum;
 
-	HAL_UART_Transmit(AX12_UART, out_data, 11, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 11, 11);
 	return ax12_read_response();
 }
 
@@ -152,7 +152,7 @@ uint8_t ax12_read_moving_status(uint8_t id)
 	out_data[6] = AX12_BYTE_READ;
 	out_data[7] = checksum;
 
-	HAL_UART_Transmit(AX12_UART, out_data, 8, 0);
+	HAL_UART_Transmit(AX12_UART, out_data, 8, 8);
 	return ax12_read_response();
 }
 
@@ -161,17 +161,17 @@ uint8_t ax12_read_response(void)
 	uint8_t data[4];
 	uint8_t error, length;
 
-	HAL_UART_Receive(AX12_UART, data, 4, 0);
+	HAL_UART_Receive(AX12_UART, data, 4, 4);
 
 	if (data[0] != 0xff)
 		return 0;
 
 	length = data[3];
 
-	HAL_UART_Receive(AX12_UART, &error, 1, 0);
+	HAL_UART_Receive(AX12_UART, &error, 1, 1);
 	unsigned char temp;
 	for (uint8_t i = 0; i < length - 1; ++i) {
-		HAL_UART_Receive(AX12_UART, &temp, 1, 0);
+		HAL_UART_Receive(AX12_UART, &temp, 1, 1);
 	}
 
 	return error;

--- a/src/drivers/actuators/motion/motion.c
+++ b/src/drivers/actuators/motion/motion.c
@@ -1,10 +1,11 @@
 #include "motion.h"
 
-volatile uint16_t x_coordinate;
-volatile uint16_t y_coordinate;
-volatile uint16_t orientation;
+volatile int16_t x_coordinate;
+volatile int16_t y_coordinate;
+volatile int16_t orientation;
 volatile char status = MOTION_IDLE;
 volatile motion_state state;
+volatile uint8_t state_refresh_needed;
 
 void set_position_and_orientation(int16_t x, int16_t y, int16_t orientation)
 {
@@ -20,16 +21,16 @@ void set_position_and_orientation(int16_t x, int16_t y, int16_t orientation)
 	out_data[6] = orientation&0xff;
 
 	// Send to motion driver
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 7, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 7, 14);
 }
 
 void read_status_and_position(void)
 {
 	uint8_t new_state[7];
 
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"P", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"P", 1, 2);
 
-	HAL_UART_Receive(MOTION_DRIVER, new_state, 7, 0);
+	HAL_UART_Receive(MOTION_DRIVER, new_state, 7, 14);
 
 	switch (new_state[0])
 	{
@@ -64,7 +65,7 @@ void set_motion_speed(int8_t speed)
 	out_data[0] = 'V';
 	out_data[1] = speed;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 2, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 2, 4);
 }
 
 void move_forward(int16_t dist)
@@ -76,7 +77,7 @@ void move_forward(int16_t dist)
 	out_data[2] = dist&0xff;
 	out_data[3] = 0;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 4, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 4, 8);
 }
 
 void rotate_for(int16_t angle)
@@ -87,7 +88,7 @@ void rotate_for(int16_t angle)
 	out_data[1] = angle>>8;
 	out_data[2] = angle&0xff;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 3, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 3, 6);
 }
 
 void rotate_to(int16_t angle)
@@ -98,7 +99,7 @@ void rotate_to(int16_t angle)
 	out_data[1] = angle>>8;
 	out_data[2] = angle&0xff;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 3, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 3, 6);
 }
 
 void goto_xy(int16_t x, int16_t y, int8_t direction)
@@ -113,7 +114,7 @@ void goto_xy(int16_t x, int16_t y, int8_t direction)
 	out_data[5] = 0;
 	out_data[6] = direction;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 7, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 7, 14);
 }
 
 void curve(int16_t x, int16_t y, int8_t angle, int8_t angle_direction, int8_t direction)
@@ -129,32 +130,32 @@ void curve(int16_t x, int16_t y, int8_t angle, int8_t angle_direction, int8_t di
 	out_data[6] = angle_direction;
 	out_data[7] = direction;
 
-	HAL_UART_Transmit(MOTION_DRIVER, out_data, 8, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, out_data, 8, 16);
 }
 
 void hard_stop(void)
 {
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"S", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"S", 1, 2);
 }
 
 void soft_stop(void)
 {
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"s", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"s", 1, 2);
 }
 
 void reset_driver(void)
 {
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"R", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"R", 1, 2);
 }
 
 void stuck_enable(void)
 {
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"Z", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"Z", 1, 2);
 }
 
 void stuck_disable(void)
 {
-	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"z", 1, 0);
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"z", 1, 2);
 }
 
 /**
@@ -163,19 +164,37 @@ void stuck_disable(void)
 void TIM7_IRQHandler(void)
 {
   /* USER CODE BEGIN TIM7_IRQn 0 */
-	uint8_t temp[7];
+//	uint8_t temp[7];
   	if (__HAL_TIM_GET_FLAG(&htim7, TIM_FLAG_UPDATE) != RESET) {
 
-  			HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"S", 1, 0);
-			HAL_UART_Receive(MOTION_DRIVER, temp, 7, 0);
-  			state.status = temp[0];
-  			state.x = (temp[1] << 8 ) | (temp[2] & 0xff);
-  			state.y = (temp[3] << 8 ) | (temp[4] & 0xff);
-  			state.orientation = (temp[5] << 8) | (temp[6] & 0xff);
-
+//  			HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"P", 1, 1);
+//			HAL_UART_Receive(MOTION_DRIVER, temp, 7, 1);
+//			switch (temp[0])
+//			{
+//				case 'I':
+//					state.status = MOTION_IDLE;
+//					break;
+//				case 'M':
+//					state.status = MOTION_MOVING;
+//					break;
+//				case 'R':
+//					state.status = MOTION_ROTATING;
+//					break;
+//				case 'S':
+//					state.status = MOTION_STUCK;
+//					break;
+//				case 'E':
+//					state.status = MOTION_ERROR;
+//					break;
+//
+//			}
+//  			state.x = (temp[1] << 8 ) | (temp[2] & 0xff);
+//  			state.y = (temp[3] << 8 ) | (temp[4] & 0xff);
+//  			state.orientation = (temp[5] << 8) | (temp[6] & 0xff);
+//  			HAL_GPIO_TogglePin(GPIOD, GPIO_PIN_15);
+			state_refresh_needed = 1;
   			/* Clear overflow interrupt flag. */
   			__HAL_TIM_CLEAR_IT(&htim7, TIM_IT_UPDATE);
-
   	}
 
   /* USER CODE END TIM7_IRQn 0 */

--- a/src/drivers/actuators/motion/motion.h
+++ b/src/drivers/actuators/motion/motion.h
@@ -8,10 +8,11 @@
 
 #define MOTION_DRIVER &huart4
 
-extern volatile uint16_t x_coordinate;
-extern volatile uint16_t y_coordinate;
-extern volatile uint16_t orientation;
+extern volatile int16_t x_coordinate;
+extern volatile int16_t y_coordinate;
+extern volatile int16_t orientation;
 extern volatile char status;
+extern volatile uint8_t state_refresh_needed;
 
 typedef enum { MOTION_IDLE,
                MOTION_STUCK,

--- a/src/executors/motion/motion.c
+++ b/src/executors/motion/motion.c
@@ -1,6 +1,7 @@
 #include "motion.h"
 #include "motion_command.h"
 
+static void refresh_state(void);
 static void motion_command_reset(void);
 static void current_motion_resume(void);
 static void motion_command_pause(void);
@@ -11,15 +12,17 @@ static double to_radian(int16_t angle);
 static void process_motion_command(void);
 static point_t calculate_curve_destination(struct curve_cmd_struct* cmd_struct);
 
-static uint8_t current_motion_command_set;
-static uint8_t motion_command_suspended = 1;
+static uint8_t current_motion_command_set = 0;
+static uint8_t command_paused = 0;
+static uint8_t motion_command_suspended = 0;
 static uint8_t giveUp = 0;
-static void* motion_queue[MAX_MOTION_QUEUE_LENGTH] = { NULL };
+static void* motion_queue[MAX_MOTION_QUEUE_LENGTH];
 static uint8_t commands_in_queue;
 static uint8_t can_use_pf = 0;
-static point_t current_destination;
+static point_t current_destination = { 0, 0 };
 static point_t previous_destination;
 static const double pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679;
+static uint8_t shouldStop = 0;
 
 typedef enum { FORWARD, BACKWARD } motion_direction;
 static motion_direction direction = FORWARD;
@@ -28,100 +31,68 @@ osMutexDef(motion_mutex_def);
 osMutexId (motion_mutex);
 
 void motion_main(void){
-	int shouldStop = 0;
 	debug("Motion executor started");
 	debug("Resetting motion command");
 	motion_command_reset();
-	while(1){
+	while(1)
+	{
 		if (shouldStop)
+		{
+			motion_command_reset();
 			break;
-		// Check if command is set and if so,
-		// check if robot can move in that direction
+		}
+		// Check if robot can go where the robot is headed
 		if (current_motion_command_set)
 		{
 			if (enemy_detected(state))
 			{
-				debug("ENEMY DETECTED");
 				if (motion_command_suspended)
 				{
 					if (!can_retry())
 					{
-						giveUp = 1;
-		//***********	PATH FINDING - START	*******************
-		//				if (should_use_pf && can_use_pf)
-		//				{
-		//					debug("Finding path");
-		//					pf_lock();
-		//					point destination = command_destination;
-		//					motion_command_reset();
-		//					giveUp = !pf_search(state.position, destination, current_motion_instruction.get_pf_positions());
-		//					pf_unlock();
-		//					debug("Path found");
-		//					if (!giveUp)
-		//					{
-		//						debug("Moving to next pf point");
-		//						current_motion_instruction.move_to_next_pf_point();
-		//					}
-		//				}
-		//***********	PATH FINDING - END	*******************
-						if (giveUp)
-						{
-							debug("Sending error, timeout, enemy detected");
-							motion_command_reset();
-							hard_stop();
-						}
+						// Commented out - path finding not ready
+//						giveUp = 1;
+//						if (can_use_pf && should_use_pf)
+//						{
+//							//path finding
+//						}
+//						if (giveUp)
+//						{
+						error("Canceling motion - enemy won't move away");
+						motion_command_reset();
+//						}
 					}
 				}
 				else
 				{
-					debug("Pausing motion - enemy detected");
+					info("Enemy detected - pausing motion");
 					motion_command_pause();
 				}
 			}
 			else if (motion_command_suspended)
 			{
-				debug("Resuming motion");
+				info("Resuming motion - way ahead is clear");
 				current_motion_resume();
 			}
-		} // if (current_motion_command_set)
-		else
-		{
-			if (osMutexWait(motion_mutex, MAX_MOTION_QUEUE_LENGTH) == osOK)
-			{
-				if (motion_queue[0] == NULL)
-				{
-					debug("No commands in motion queue");
-				}
-				else
-				{
-					debug("Grabbing new command from queue");
-					process_motion_command();
-				}
-			}
-			else
-			{
-				error("MOTION CAN'T GET MUTEX");
-			}
 		}
-		if ((state.status == MOTION_IDLE || state.status == MOTION_STUCK || state.status == MOTION_ERROR) && current_motion_command_set)
+		// Process next command
+		if (motion_queue[0] != NULL && state.status == MOTION_IDLE && current_motion_command_set == 0)
 		{
-			if (state.status == MOTION_IDLE)
-			{
-				info("Done executin command");
-				current_motion_command_set = 0;
-			}
-			else if (state.status == MOTION_STUCK)
-			{
-				error("STUCK");
-				motion_command_reset();
-				hard_stop();
-			}
-			else if (state.status == MOTION_ERROR)
-			{
-				error("Error - canceling motion");
-				motion_command_reset();
-				hard_stop();
-			}
+			osDelay(1);
+			refresh_state();
+			process_motion_command();
+		}
+		// Refresh state data
+		if (state_refresh_needed)
+			refresh_state();
+		// Say that you're done moving
+		if (state.status == MOTION_IDLE && current_motion_command_set && !command_paused)
+			current_motion_command_set = 0;
+		if ((state.status == MOTION_ERROR || state.status == MOTION_STUCK) && current_motion_command_set)
+		{
+			if (state.status == MOTION_ERROR) error("Motion command error");
+			if (state.status == MOTION_STUCK) error("Motion stuck!");
+			motion_command_reset();
 		}
 		osDelay(6);
 	} // while(1)
@@ -129,9 +100,9 @@ void motion_main(void){
 
 static void current_motion_resume(void)
 {
-	debug("current_motion_resume");
 	current_destination = previous_destination;
-	goto_xy_cmd(current_destination.x, current_destination.y, direction, can_use_pf);
+	motion_command_suspended = 0;
+	goto_xy(current_destination.x, current_destination.y, direction);
 }
 
 static void motion_command_reset(void)
@@ -146,16 +117,18 @@ static void motion_command_pause(void)
 	debug("motion_command_pause");
 	hard_stop();
 	previous_destination = current_destination;
+	motion_command_suspended = 1;
+	command_paused = 1;
 }
 
 static uint8_t enemy_detected(motion_state state)
 {
-	debug("enemy_detected");
 	if (state.status == MOTION_ROTATING)
 		return 0;
+	// If nothing on the moving side
 	if ((direction == FORWARD && !(FRONT_LEFT_SENSOR ||
-                                   FRONT_RIGHT_SENSOR)) ||
-		(direction == BACKWARD && !BACK_SENSOR))
+			FRONT_RIGHT_SENSOR)) ||
+			(direction == BACKWARD && !BACK_SENSOR))
 		return 0;
 	point_t enemy;
 	enemy.x = state.x + CENTER_TO_CENTER * cos(to_radian(state.orientation));
@@ -170,18 +143,26 @@ void motion_queue_push(void* command)
 	if (commands_in_queue >= MAX_MOTION_QUEUE_LENGTH)
 	{
 		error("Motion queue already full.\n"
-		"Currently in queue: %d", commands_in_queue);
+				"Currently in queue: %d", commands_in_queue);
+
+		vPortFree(command);
 	}
 	else
 	{
-		if (osMutexWait(motion_mutex, MAX_MOTION_QUEUE_LENGTH) == osOK)
+		if (osMutexWait(motion_mutex, MOTION_MUTEX_WAIT_MS) == osOK)
 		{
 			motion_queue[commands_in_queue] = command;
 			commands_in_queue++;
+
+			//			osDelay(1);
+
+			osMutexRelease(motion_mutex);
+
+			osThreadYield();
 		}
 		else
 		{
-			error("MOTION CAN'T GET MUTEX");
+			error("MOTION CAN'T GET MUTEX - PUSH");
 		}
 	}
 
@@ -196,16 +177,20 @@ void* motion_queue_pull(void)
 	}
 	else
 	{
-		if (osMutexWait(motion_mutex, MAX_MOTION_QUEUE_LENGTH) == osOK)
+		if (osMutexWait(motion_mutex, MOTION_MUTEX_WAIT_MS) == osOK)
 		{
 			command = motion_queue[0];
 			memmove(motion_queue, motion_queue + 1, commands_in_queue - 1);
 			commands_in_queue--;
 			motion_queue[commands_in_queue] = NULL;
+
+			osMutexRelease(motion_mutex);
+
+			osThreadYield();
 		}
 		else
 		{
-			error("MOTION CAN'T GET MUTEX");
+			error("MOTION CAN'T GET MUTEX - PULL");
 		}
 	}
 	return command;
@@ -213,7 +198,7 @@ void* motion_queue_pull(void)
 
 uint8_t can_retry(void)
 {
-	static uint8_t retry_count;
+	static uint16_t retry_count;
 	if (retry_count >= MAX_RETRY_COUNT)
 	{
 		retry_count = 0;
@@ -228,18 +213,17 @@ uint8_t can_retry(void)
 
 uint8_t is_in_field(point_t enemy)
 {
-	if (enemy.x > 0 && enemy.x < 2000 && enemy.y > 0 && enemy.y < 3000)
+	if (enemy.x > X_MIN && enemy.x < X_MAX && enemy.y > Y_MIN && enemy.y < Y_MAX)
 	{
-		if (enemy.x > 0 && enemy.x < 350 &&
-			((enemy.y > 0 && enemy.y < 1050) ||
-			 (enemy.y > 1950 && enemy.y < 3000)))
+		if (enemy.x > START_FIELD_X_MIN && enemy.x < START_FIELD_X_MAX &&
+				((enemy.y > ALLY_START_FIELD_Y_MAX && enemy.y < ENEMY_START_FIEL_Y_MIN)))
 		{
 			debug("Detected enemy is in start field");
 			return 0;
 		}
 		else
 		{
-			debug("Detencted enemy is in allower area");
+			debug("Detencted enemy is in allowed area");
 			return 1;
 		}
 	}
@@ -259,115 +243,135 @@ static double to_radian(int16_t angle)
 static void process_motion_command(void)
 {
 	// TODO: What if no more commands?
+	static int cnt = 0;
 	void* cmd_temp = motion_queue_pull();
-	motion_cmd_id_t id = * (motion_cmd_id_t*) cmd_temp;
-	switch (id)
+	motion_cmd_id_t id = ((struct set_xy_cmd_struct*)cmd_temp)->id;
+	debug("Motion Command ID = %d\tCnt = %d", id, ++cnt);
+	switch (id){
+	case SET_XY:
 	{
-		case SET_XY:
-			{
-				struct set_xy_cmd_struct* cmd = (struct set_xy_cmd_struct*)cmd_temp;
-				set_position_and_orientation(cmd->x, cmd->y, cmd->orientation);
-				break;
-			}
-		case READ_STATUS:
-			{
-				//struct read_status_cmd_struct* cmd = cmd_temp;
-				read_status_and_position();
-				break;
-			}
-		case MOVE_FORWARD:
-			{
-				struct move_forward_cmd_struct* cmd = cmd_temp;
-				current_motion_command_set = 1;
-				can_use_pf = 0;
-				current_destination.x = state.x + cmd->dist * cos(to_radian(state.orientation));
-				current_destination.y = state.y + cmd->dist * sin(to_radian(state.orientation));
-				if (cmd->dist > 0)
-					direction = FORWARD;
-				else
-					direction = BACKWARD;
-				move_forward(cmd->dist);
-				break;
-			}
-		case ROTATE_FOR:
-			{
-				struct rotate_for_cmd_struct* cmd = cmd_temp;
-				current_motion_command_set = 1;
-				can_use_pf = 0;
-				current_destination.x = state.x;
-				current_destination.y = state.y;
-				rotate_for(cmd->angle);
-				break;
-			}
-		case ROTATE_TO:
-			{
-				struct rotate_to_cmd_struct* cmd = cmd_temp;
-				current_motion_command_set = 1;
-				can_use_pf = 0;
-				current_destination.x = state.x;
-				current_destination.y = state.y;
-				rotate_to(cmd->angle);
-				break;
-			}
-		case GOTO_XY:
-			{
-				struct goto_xy_cmd_struct* cmd = cmd_temp;
-				current_motion_command_set = 1;
-				can_use_pf = cmd->use_pf;
-				current_destination.x = cmd->x;
-				current_destination.y = cmd->y;
-				direction = cmd->direction? FORWARD : BACKWARD;
-				goto_xy(cmd->x, cmd->y, cmd->direction);
-				break;
-			}
-		case CURVE:
-			{
-				struct curve_cmd_struct* cmd = cmd_temp;
-				current_motion_command_set = 1;
-				can_use_pf = 0;
-				current_destination = calculate_curve_destination(cmd);
-				direction = cmd->direction;
-				curve(cmd->x, cmd->y, cmd->angle, cmd->angle_direction, cmd->direction);
-				break;
-			}
-		case HARD_STOP:
-			{
-				//struct hard_stop_cmd_struct* cmd = cmd_temp;
-				hard_stop();
-				break;
-			}
-		case SOFT_STOP:
-			{
-				//struct soft_stop_cmd_struct* cmd = cmd_temp;
-				soft_stop();
-				break;
-			}
-		case RESET_DRIVER:
-			{
-				//struct reset_driver_cmd_struct* cmd = cmd_temp;
-				reset_driver();
-				break;
-			}
-		case STUCK_ENABLE:
-			{
-				//struct stuck_enable_cmd_struct* cmd = cmd_temp;
-				stuck_enable();
-				break;
-			}
-		case STUCK_DISABLE:
-			{
-				//struct stuck_disable_cmd_struct* cmd = cmd_temp;
-				stuck_disable();
-				break;
-			}
-		case SET_SPEED:
-			{
-				struct set_motion_speed_cmd_struct* cmd = cmd_temp;
-				set_motion_speed(cmd->speed);
-				break;
-			}
-		default:
-			error("Unknown motion command id");
+		struct set_xy_cmd_struct* cmd = cmd_temp;
+		set_position_and_orientation(cmd->x, cmd->y, cmd->orientation);
+		vPortFree(cmd);
+		break;
+	}
+	case READ_STATUS:
+	{
+		//struct read_status_cmd_struct* cmd = cmd_temp;
+		read_status_and_position();
+		break;
+	}
+	case MOVE_FORWARD:
+	{
+		struct move_forward_cmd_struct* cmd = cmd_temp;
+		current_motion_command_set = 1;
+		can_use_pf = 0;
+		current_destination.x = state.x + cmd->dist * cos(to_radian(state.orientation));
+		current_destination.y = state.y + cmd->dist * sin(to_radian(state.orientation));
+		if (cmd->dist > 0)
+			direction = FORWARD;
+		else
+			direction = BACKWARD;
+		move_forward(cmd->dist);
+		vPortFree(cmd);
+		break;
+	}
+	case ROTATE_FOR:
+	{
+		struct rotate_for_cmd_struct* cmd = cmd_temp;
+		debug("rotate for: %d",cmd->angle);
+		current_motion_command_set = 1;
+		can_use_pf = 0;
+		current_destination.x = state.x;
+		current_destination.y = state.y;
+		HAL_TIM_Base_Stop_IT(&htim7);
+		rotate_for(cmd->angle);
+		HAL_TIM_Base_Start_IT(&htim7);
+		vPortFree(cmd);
+		break;
+	}
+	case ROTATE_TO:
+	{
+		struct rotate_to_cmd_struct* cmd = cmd_temp;
+		debug("rotate to: %d",cmd->angle);
+		current_motion_command_set = 1;
+		can_use_pf = 0;
+		current_destination.x = state.x;
+		current_destination.y = state.y;
+		rotate_to(cmd->angle);
+		vPortFree(cmd);
+		break;
+	}
+	case GOTO_XY:
+	{
+		struct goto_xy_cmd_struct* cmd = cmd_temp;
+		debug("go to x: %d, y: %d, direction: %d",cmd->x,cmd->y,cmd->direction);
+		current_motion_command_set = 1;
+		can_use_pf = cmd->use_pf;
+		current_destination.x = cmd->x;
+		current_destination.y = cmd->y;
+		direction = cmd->direction? FORWARD : BACKWARD;
+		goto_xy(cmd->x, cmd->y, cmd->direction);
+		vPortFree(cmd);
+		break;
+	}
+	case CURVE:
+	{
+		struct curve_cmd_struct* cmd = cmd_temp;
+		debug("curve: ");
+		current_motion_command_set = 1;
+		can_use_pf = 0;
+		current_destination = calculate_curve_destination(cmd);
+		direction = cmd->direction;
+		curve(cmd->x, cmd->y, cmd->angle, cmd->angle_direction, cmd->direction);
+		vPortFree(cmd);
+		break;
+	}
+	case HARD_STOP:
+	{
+		//struct hard_stop_cmd_struct* cmd = cmd_temp;
+		debug("hard stop");
+		hard_stop();
+		break;
+	}
+	case SOFT_STOP:
+	{
+		//struct soft_stop_cmd_struct* cmd = cmd_temp;
+		debug("soft stop");
+		soft_stop();
+		break;
+	}
+	case RESET_DRIVER:
+	{
+		//struct reset_driver_cmd_struct* cmd = cmd_temp;
+		debug("reset driver");
+		reset_driver();
+		break;
+	}
+	case STUCK_ENABLE:
+	{
+		//struct stuck_enable_cmd_struct* cmd = cmd_temp;
+		debug("stuck enable");
+		stuck_enable();
+		break;
+	}
+	case STUCK_DISABLE:
+	{
+		//struct stuck_disable_cmd_struct* cmd = cmd_temp;
+		debug("stuck disable");
+		stuck_disable();
+		break;
+	}
+	case SET_SPEED:
+	{
+		struct set_motion_speed_cmd_struct* cmd = cmd_temp;
+		debug("set speed: %d", cmd->speed);
+		set_motion_speed(cmd->speed);
+		vPortFree(cmd);
+		break;
+	}
+	default:
+		error("Unknown motion command id");
 	}
 }
 
@@ -375,4 +379,53 @@ point_t calculate_curve_destination(struct curve_cmd_struct* cmd_struct)
 {
 	point_t dest = { 0, 0 };
 	return dest;
+}
+
+void motion_ctor(void)
+{
+	motion_mutex = osMutexCreate(osMutex(motion_mutex_def));
+
+	if (motion_mutex == NULL)
+	{
+		error("Motion mutex not created - exiting");
+		shouldStop = 1;
+	}
+	else
+	{
+		info("Motion mutex created - All good");
+	}
+}
+
+void refresh_state(void)
+{
+	uint8_t temp[7];
+	//	debug("sending P");
+	HAL_UART_Transmit(MOTION_DRIVER, (unsigned char *)"P", 1, 1);
+	//	debug("P sent");
+	HAL_UART_Receive(MOTION_DRIVER, temp, 7, 50);
+	//	debug("got data");
+	switch (temp[0])
+	{
+	case 'I':
+		state.status = MOTION_IDLE;
+		break;
+	case 'M':
+		state.status = MOTION_MOVING;
+		break;
+	case 'R':
+		state.status = MOTION_ROTATING;
+		break;
+	case 'S':
+		state.status = MOTION_STUCK;
+		break;
+	case 'E':
+		state.status = MOTION_ERROR;
+		break;
+
+	}
+	state.x = (temp[1] << 8 ) | (temp[2] & 0xff);
+	state.y = (temp[3] << 8 ) | (temp[4] & 0xff);
+	state.orientation = (temp[5] << 8) | (temp[6] & 0xff);
+
+	state_refresh_needed = 0;
 }

--- a/src/executors/motion/motion.h
+++ b/src/executors/motion/motion.h
@@ -10,13 +10,22 @@
 #include <math.h>
 
 #define FRONT_LEFT_SENSOR optical_sensor_3
-#define FRONT_RIGHT_SENSOR optical_sensor_5
-#define BACK_SENSOR optical_sensor_8
+#define FRONT_RIGHT_SENSOR optical_sensor_1
+#define BACK_SENSOR optical_sensor_5
 
 #define MOTION_MUTEX_WAIT_MS 2
 #define MAX_MOTION_QUEUE_LENGTH 50
-#define MAX_RETRY_COUNT 5
+#define MAX_RETRY_COUNT 500
 #define CENTER_TO_CENTER 450
+#define Y_MIN 0
+#define Y_MAX 3000
+#define X_MIN 0
+#define X_MAX 2000
+#define START_FIELD_X_MIN 0
+#define START_FIELD_X_MAX 350
+#define ALLY_START_FIELD_Y_MAX 350
+#define ENEMY_START_FIEL_Y_MIN 2650
+
 
 void motion_queue_push(void* command);
 void* motion_queue_pull(void);
@@ -26,5 +35,7 @@ void* motion_queue_pull(void);
  * @brief motion main function. It runs in own thread
  */
 void motion_main(void);
+
+void motion_ctor(void);
 
 # endif // EXECUTORS_MOTION_H

--- a/src/executors/motion/motion_command.c
+++ b/src/executors/motion/motion_command.c
@@ -2,108 +2,160 @@
 
 void set_xy_cmd(int16_t x, int16_t y, int16_t orientation)
 {
-	struct set_xy_cmd_struct command_struct;
-	command_struct.id = SET_XY;
-	command_struct.x = x;
-	command_struct.y = y;
-	command_struct.orientation = orientation;
-	motion_queue_push(&command_struct);
+	struct set_xy_cmd_struct* command_struct = pvPortMalloc(sizeof(struct set_xy_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = SET_XY;
+		command_struct->x = x;
+		command_struct->y = y;
+		command_struct->orientation = orientation;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void read_status_cmd(void)
 {
-	struct read_status_cmd_struct command_struct;
-	command_struct.id = READ_STATUS;
-	motion_queue_push(&command_struct);
+	struct read_status_cmd_struct* command_struct = pvPortMalloc(sizeof(struct read_status_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = READ_STATUS;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void move_forward_cmd(int16_t dist)
 {
-	struct move_forward_cmd_struct command_struct;
-	command_struct.id = MOVE_FORWARD;
-	command_struct.dist = dist;
-	motion_queue_push(&command_struct);
+	struct move_forward_cmd_struct* command_struct = pvPortMalloc(sizeof(struct move_forward_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = MOVE_FORWARD;
+		command_struct->dist = dist;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void rotate_for_cmd(int16_t angle)
 {
-	struct rotate_for_cmd_struct command_struct;
-	command_struct.id = ROTATE_FOR;
-	command_struct.angle = angle;
-	motion_queue_push(&command_struct);
+	struct rotate_for_cmd_struct* command_struct = pvPortMalloc(sizeof(struct rotate_for_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = ROTATE_FOR;
+		command_struct->angle = angle;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void rotate_to_cmd(int16_t angle)
 {
-	struct rotate_for_cmd_struct command_struct;
-	command_struct.id = ROTATE_TO;
-	command_struct.angle = angle;
-	motion_queue_push(&command_struct);
+	struct rotate_to_cmd_struct* command_struct = pvPortMalloc(sizeof(struct rotate_to_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = ROTATE_TO;
+		command_struct->angle = angle;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void goto_xy_cmd(int16_t x, int16_t y, int8_t direction, uint8_t use_pf)
 {
-	struct goto_xy_cmd_struct command_struct;
-	command_struct.id = GOTO_XY;
-	command_struct.x = x;
-	command_struct.y = y;
-	command_struct.direction = direction;
-	command_struct.use_pf = use_pf;
-	motion_queue_push(&command_struct);
+	struct goto_xy_cmd_struct* command_struct = pvPortMalloc(sizeof(struct goto_xy_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = GOTO_XY;
+		command_struct->x = x;
+		command_struct->y = y;
+		command_struct->direction = direction;
+		command_struct->use_pf = use_pf;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void curve_cmd(int16_t x, int16_t y, int8_t angle, int8_t angle_direction,
 		int8_t direction)
 {
-	struct curve_cmd_struct command_struct;
-	command_struct.id = CURVE;
-	command_struct.x = x;
-	command_struct.y = y;
-	command_struct.angle = angle;
-	command_struct.angle_direction = angle_direction;
-	command_struct.direction = direction;
-	motion_queue_push(&command_struct);
+	struct curve_cmd_struct* command_struct = pvPortMalloc(sizeof(struct curve_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = CURVE;
+		command_struct->x = x;
+		command_struct->y = y;
+		command_struct->angle = angle;
+		command_struct->angle_direction = angle_direction;
+		command_struct->direction = direction;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void hard_stop_cmd(void)
 {
-	struct hard_stop_cmd_struct command_struct;
-	command_struct.id = HARD_STOP;
-	motion_queue_push(&command_struct);
+	struct hard_stop_cmd_struct* command_struct = pvPortMalloc(sizeof(struct hard_stop_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = HARD_STOP;
+		motion_queue_push(command_struct);
+	}else{
+		error("malloc");
+	}
 }
 
 void soft_stop_cmd(void)
 {
-	struct soft_stop_cmd_struct command_struct;
-	command_struct.id = HARD_STOP;
-	motion_queue_push(&command_struct);
+	struct soft_stop_cmd_struct* command_struct = pvPortMalloc(sizeof(struct soft_stop_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = SOFT_STOP;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void reset_driver_cmd(void)
 {
-	struct reset_driver_cmd_struct command_struct;
-	command_struct.id = HARD_STOP;
-	motion_queue_push(&command_struct);
+	struct reset_driver_cmd_struct* command_struct = pvPortMalloc(sizeof(struct reset_driver_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = RESET_DRIVER;
+		motion_queue_push(command_struct);
+	}else{
+		error("malloc");
+	}
 }
 
 void stuck_enable_cmd(void)
 {
-	struct stuck_enable_cmd_struct command_struct;
-	command_struct.id = HARD_STOP;
-	motion_queue_push(&command_struct);
+	struct stuck_enable_cmd_struct* command_struct = pvPortMalloc(sizeof(struct stuck_enable_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = STUCK_ENABLE;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void stuck_disable_cmd(void)
 {
-	struct stuck_disable_cmd_struct command_struct;
-	command_struct.id = HARD_STOP;
-	motion_queue_push(&command_struct);
+	struct stuck_disable_cmd_struct* command_struct = pvPortMalloc(sizeof(struct stuck_disable_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = STUCK_DISABLE;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }
 
 void set_motion_speed_cmd(uint8_t speed)
 {
-	struct set_motion_speed_cmd_struct command_struct;
-	command_struct.id = SET_SPEED;
-	command_struct.speed = speed;
-	motion_queue_push(&command_struct);
+	struct set_motion_speed_cmd_struct* command_struct = pvPortMalloc(sizeof(struct set_motion_speed_cmd_struct));
+	if(command_struct != NULL){
+		command_struct->id = SET_SPEED;
+		command_struct->speed = speed;
+		motion_queue_push(command_struct);
+	}else{
+		error("motion_command malloc error");
+	}
 }

--- a/src/executors/motion/motion_command.h
+++ b/src/executors/motion/motion_command.h
@@ -2,6 +2,7 @@
 #define MOTION_COMMAND_H
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "cmsis_os.h"
 #include "usart.h"

--- a/src/initialisation/FreeRTOSConfig.h
+++ b/src/initialisation/FreeRTOSConfig.h
@@ -97,7 +97,7 @@
 #define configUSE_IDLE_HOOK                      0
 #define configUSE_TICK_HOOK                      0
 #define configCPU_CLOCK_HZ                       ( SystemCoreClock )
-#define configTICK_RATE_HZ                       ((TickType_t)1000)
+#define configTICK_RATE_HZ                       ((TickType_t)100)
 #define configMAX_PRIORITIES                     ( 7 )
 #define configMINIMAL_STACK_SIZE                 ((uint16_t)128)
 #define configTOTAL_HEAP_SIZE                    ((size_t)15360)

--- a/src/initialisation/freertos.c
+++ b/src/initialisation/freertos.c
@@ -50,7 +50,7 @@
 #include "../executors/motion/motion.h"
 #include "../executors/common/common.h"
 
-/* USER CODE BEGIN Includes */     
+/* USER CODE BEGIN Includes */
 
 /* USER CODE END Includes */
 
@@ -68,7 +68,7 @@ osThreadId commonThreadHandle;
 //void StartDefaultTask(void const * argument);
 extern void motion_main(void);
 extern void tasks_main(void);
-extern void common_main(void);
+//extern void common_main(void);
 
 void MX_FREERTOS_Init(void); /* (MISRA C 2004 rule 8.1) */
 
@@ -90,6 +90,7 @@ void MX_FREERTOS_Init(void) {
 	/* add mutexes, ... */
 
 	logger_ctor();
+	motion_ctor();
 	/* USER CODE END RTOS_MUTEX */
 
 	/* USER CODE BEGIN RTOS_SEMAPHORES */

--- a/src/initialisation/tim.c
+++ b/src/initialisation/tim.c
@@ -5,37 +5,37 @@
   *                      of the TIM instances.
   ******************************************************************************
   *
-  * Copyright (c) 2017 STMicroelectronics International N.V. 
+  * Copyright (c) 2017 STMicroelectronics International N.V.
   * All rights reserved.
   *
-  * Redistribution and use in source and binary forms, with or without 
+  * Redistribution and use in source and binary forms, with or without
   * modification, are permitted, provided that the following conditions are met:
   *
-  * 1. Redistribution of source code must retain the above copyright notice, 
+  * 1. Redistribution of source code must retain the above copyright notice,
   *    this list of conditions and the following disclaimer.
   * 2. Redistributions in binary form must reproduce the above copyright notice,
   *    this list of conditions and the following disclaimer in the documentation
   *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other 
-  *    contributors to this software may be used to endorse or promote products 
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
   *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this 
+  * 4. This software, including modifications and/or derivative works of this
   *    software, must execute solely and exclusively on microcontroller or
   *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under 
-  *    this license is void and will automatically terminate your rights under 
-  *    this license. 
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
   *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" 
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT 
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
   * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT 
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
   * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
   * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
@@ -69,10 +69,10 @@ void MX_TIM1_Init(void)
   TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig;
 
   htim1.Instance = TIM1;
-  htim1.Init.Prescaler = 0;
+  htim1.Init.Prescaler = 52;
   htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim1.Init.Period = 0;
-  htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim1.Init.Period = 16000;
+  htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;
   htim1.Init.RepetitionCounter = 0;
   if (HAL_TIM_PWM_Init(&htim1) != HAL_OK)
   {
@@ -87,7 +87,7 @@ void MX_TIM1_Init(void)
   }
 
   sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
+  sConfigOC.Pulse = 100;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
@@ -120,10 +120,10 @@ void MX_TIM2_Init(void)
   TIM_OC_InitTypeDef sConfigOC;
 
   htim2.Instance = TIM2;
-  htim2.Init.Prescaler = 0;
+  htim2.Init.Prescaler = 26;
   htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim2.Init.Period = 0;
-  htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim2.Init.Period = 800;
+  htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV2;
   if (HAL_TIM_PWM_Init(&htim2) != HAL_OK)
   {
     Error_Handler();
@@ -155,10 +155,10 @@ void MX_TIM3_Init(void)
   TIM_OC_InitTypeDef sConfigOC;
 
   htim3.Instance = TIM3;
-  htim3.Init.Prescaler = 0;
+  htim3.Init.Prescaler = 26;
   htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim3.Init.Period = 0;
-  htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim3.Init.Period = 16000;
+  htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;
   if (HAL_TIM_PWM_Init(&htim3) != HAL_OK)
   {
     Error_Handler();
@@ -172,7 +172,7 @@ void MX_TIM3_Init(void)
   }
 
   sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
+  sConfigOC.Pulse = 100;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
   if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) != HAL_OK)
@@ -195,9 +195,9 @@ void MX_TIM4_Init(void)
   TIM_OC_InitTypeDef sConfigOC;
 
   htim4.Instance = TIM4;
-  htim4.Init.Prescaler = 0;
+  htim4.Init.Prescaler = 26;
   htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim4.Init.Period = 0;
+  htim4.Init.Period = 16000;
   htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
   if (HAL_TIM_PWM_Init(&htim4) != HAL_OK)
   {
@@ -212,7 +212,7 @@ void MX_TIM4_Init(void)
   }
 
   sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
+  sConfigOC.Pulse = 100;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
   if (HAL_TIM_PWM_ConfigChannel(&htim4, &sConfigOC, TIM_CHANNEL_2) != HAL_OK)
@@ -229,9 +229,9 @@ void MX_TIM6_Init(void)
   TIM_MasterConfigTypeDef sMasterConfig;
 
   htim6.Instance = TIM6;
-  htim6.Init.Prescaler = 0;
+  htim6.Init.Prescaler = 420;
   htim6.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim6.Init.Period = 0;
+  htim6.Init.Period = 10000;
   if (HAL_TIM_Base_Init(&htim6) != HAL_OK)
   {
     Error_Handler();
@@ -251,9 +251,9 @@ void MX_TIM7_Init(void)
   TIM_MasterConfigTypeDef sMasterConfig;
 
   htim7.Instance = TIM7;
-  htim7.Init.Prescaler = 0;
+  htim7.Init.Prescaler = 420;
   htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim7.Init.Period = 0;
+  htim7.Init.Period = 1000;
   if (HAL_TIM_Base_Init(&htim7) != HAL_OK)
   {
     Error_Handler();
@@ -273,17 +273,17 @@ void MX_TIM9_Init(void)
   TIM_OC_InitTypeDef sConfigOC;
 
   htim9.Instance = TIM9;
-  htim9.Init.Prescaler = 0;
+  htim9.Init.Prescaler = 105;
   htim9.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim9.Init.Period = 0;
-  htim9.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim9.Init.Period = 16000;
+  htim9.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;
   if (HAL_TIM_PWM_Init(&htim9) != HAL_OK)
   {
     Error_Handler();
   }
 
   sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
+  sConfigOC.Pulse = 100;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
   if (HAL_TIM_PWM_ConfigChannel(&htim9, &sConfigOC, TIM_CHANNEL_1) != HAL_OK)
@@ -307,8 +307,8 @@ void MX_TIM10_Init(void)
   htim10.Instance = TIM10;
   htim10.Init.Prescaler = 0;
   htim10.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim10.Init.Period = 0;
-  htim10.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim10.Init.Period = 8399;
+  htim10.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;
   if (HAL_TIM_Base_Init(&htim10) != HAL_OK)
   {
     Error_Handler();
@@ -320,7 +320,7 @@ void MX_TIM10_Init(void)
   }
 
   sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = 0;
+  sConfigOC.Pulse = 8000;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
   if (HAL_TIM_PWM_ConfigChannel(&htim10, &sConfigOC, TIM_CHANNEL_1) != HAL_OK)
@@ -339,7 +339,7 @@ void MX_TIM12_Init(void)
   htim12.Instance = TIM12;
   htim12.Init.Prescaler = 0;
   htim12.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim12.Init.Period = 0;
+  htim12.Init.Period = 10000;
   htim12.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
   if (HAL_TIM_Base_Init(&htim12) != HAL_OK)
   {
@@ -469,9 +469,9 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* tim_baseHandle)
   /* USER CODE END TIM12_MspInit 0 */
     /* Peripheral clock enable */
     __HAL_RCC_TIM12_CLK_ENABLE();
-  
-    /**TIM12 GPIO Configuration    
-    PB15     ------> TIM12_CH2 
+
+    /**TIM12 GPIO Configuration
+    PB15     ------> TIM12_CH2
     */
     GPIO_InitStruct.Pin = TIM12_CH12_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -494,8 +494,8 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM1_MspPostInit 0 */
 
   /* USER CODE END TIM1_MspPostInit 0 */
-    /**TIM1 GPIO Configuration    
-    PA8     ------> TIM1_CH1 
+    /**TIM1 GPIO Configuration
+    PA8     ------> TIM1_CH1
     */
     GPIO_InitStruct.Pin = TIM1_CH1_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -513,9 +513,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM2_MspPostInit 0 */
 
   /* USER CODE END TIM2_MspPostInit 0 */
-  
-    /**TIM2 GPIO Configuration    
-    PA15     ------> TIM2_CH1 
+
+    /**TIM2 GPIO Configuration
+    PA15     ------> TIM2_CH1
     */
     GPIO_InitStruct.Pin = TIM2_CH1_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -533,10 +533,10 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM3_MspPostInit 0 */
 
   /* USER CODE END TIM3_MspPostInit 0 */
-  
-    /**TIM3 GPIO Configuration    
+
+    /**TIM3 GPIO Configuration
     PB4     ------> TIM3_CH1
-    PB5     ------> TIM3_CH2 
+    PB5     ------> TIM3_CH2
     */
     GPIO_InitStruct.Pin = TIM3_CH1_Pin|TIM3_CH2_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -554,9 +554,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM4_MspPostInit 0 */
 
   /* USER CODE END TIM4_MspPostInit 0 */
-  
-    /**TIM4 GPIO Configuration    
-    PB7     ------> TIM4_CH2 
+
+    /**TIM4 GPIO Configuration
+    PB7     ------> TIM4_CH2
     */
     GPIO_InitStruct.Pin = TIM4_CH2_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -574,10 +574,10 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM9_MspPostInit 0 */
 
   /* USER CODE END TIM9_MspPostInit 0 */
-  
-    /**TIM9 GPIO Configuration    
+
+    /**TIM9 GPIO Configuration
     PE5     ------> TIM9_CH1
-    PE6     ------> TIM9_CH2 
+    PE6     ------> TIM9_CH2
     */
     GPIO_InitStruct.Pin = TIM9_CH1___Door_poke_servo_Pin|TIM9_CH2___Door_servo_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -595,9 +595,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM10_MspPostInit 0 */
 
   /* USER CODE END TIM10_MspPostInit 0 */
-  
-    /**TIM10 GPIO Configuration    
-    PB8     ------> TIM10_CH1 
+
+    /**TIM10 GPIO Configuration
+    PB8     ------> TIM10_CH1
     */
     GPIO_InitStruct.Pin = TIM10_CH1_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -724,9 +724,9 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* tim_baseHandle)
   /* USER CODE END TIM12_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_TIM12_CLK_DISABLE();
-  
-    /**TIM12 GPIO Configuration    
-    PB15     ------> TIM12_CH2 
+
+    /**TIM12 GPIO Configuration
+    PB15     ------> TIM12_CH2
     */
     HAL_GPIO_DeInit(TIM12_CH12_GPIO_Port, TIM12_CH12_Pin);
 
@@ -734,7 +734,7 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* tim_baseHandle)
 
   /* USER CODE END TIM12_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/src/initialisation/usart.c
+++ b/src/initialisation/usart.c
@@ -5,37 +5,37 @@
   *                      of the USART instances.
   ******************************************************************************
   *
-  * Copyright (c) 2017 STMicroelectronics International N.V. 
+  * Copyright (c) 2017 STMicroelectronics International N.V.
   * All rights reserved.
   *
-  * Redistribution and use in source and binary forms, with or without 
+  * Redistribution and use in source and binary forms, with or without
   * modification, are permitted, provided that the following conditions are met:
   *
-  * 1. Redistribution of source code must retain the above copyright notice, 
+  * 1. Redistribution of source code must retain the above copyright notice,
   *    this list of conditions and the following disclaimer.
   * 2. Redistributions in binary form must reproduce the above copyright notice,
   *    this list of conditions and the following disclaimer in the documentation
   *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other 
-  *    contributors to this software may be used to endorse or promote products 
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
   *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this 
+  * 4. This software, including modifications and/or derivative works of this
   *    software, must execute solely and exclusively on microcontroller or
   *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under 
-  *    this license is void and will automatically terminate your rights under 
-  *    this license. 
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
   *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" 
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT 
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
   * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT 
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
   * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
   * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
@@ -60,7 +60,7 @@ void MX_UART4_Init(void)
 {
 
   huart4.Instance = UART4;
-  huart4.Init.BaudRate = 115200;
+  huart4.Init.BaudRate = 57600;
   huart4.Init.WordLength = UART_WORDLENGTH_8B;
   huart4.Init.StopBits = UART_STOPBITS_1;
   huart4.Init.Parity = UART_PARITY_NONE;
@@ -123,10 +123,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END UART4_MspInit 0 */
     /* Peripheral clock enable */
     __HAL_RCC_UART4_CLK_ENABLE();
-  
-    /**UART4 GPIO Configuration    
+
+    /**UART4 GPIO Configuration
     PA0-WKUP     ------> UART4_TX
-    PA1     ------> UART4_RX 
+    PA1     ------> UART4_RX
     */
     GPIO_InitStruct.Pin = UART4_TX_Pin|UART4_RX_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -146,9 +146,9 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END USART2_MspInit 0 */
     /* Peripheral clock enable */
     __HAL_RCC_USART2_CLK_ENABLE();
-  
-    /**USART2 GPIO Configuration    
-    PA2     ------> USART2_TX 
+
+    /**USART2 GPIO Configuration
+    PA2     ------> USART2_TX
     */
     GPIO_InitStruct.Pin = USART2_TX_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
@@ -168,10 +168,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END USART3_MspInit 0 */
     /* Peripheral clock enable */
     __HAL_RCC_USART3_CLK_ENABLE();
-  
-    /**USART3 GPIO Configuration    
+
+    /**USART3 GPIO Configuration
     PB11     ------> USART3_RX
-    PD8     ------> USART3_TX 
+    PD8     ------> USART3_TX
     */
     GPIO_InitStruct.Pin = USART3_RX_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -203,10 +203,10 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END UART4_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_UART4_CLK_DISABLE();
-  
-    /**UART4 GPIO Configuration    
+
+    /**UART4 GPIO Configuration
     PA0-WKUP     ------> UART4_TX
-    PA1     ------> UART4_RX 
+    PA1     ------> UART4_RX
     */
     HAL_GPIO_DeInit(GPIOA, UART4_TX_Pin|UART4_RX_Pin);
 
@@ -221,9 +221,9 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END USART2_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_USART2_CLK_DISABLE();
-  
-    /**USART2 GPIO Configuration    
-    PA2     ------> USART2_TX 
+
+    /**USART2 GPIO Configuration
+    PA2     ------> USART2_TX
     */
     HAL_GPIO_DeInit(USART2_TX_GPIO_Port, USART2_TX_Pin);
 
@@ -238,10 +238,10 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
   /* USER CODE END USART3_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_USART3_CLK_DISABLE();
-  
-    /**USART3 GPIO Configuration    
+
+    /**USART3 GPIO Configuration
     PB11     ------> USART3_RX
-    PD8     ------> USART3_TX 
+    PD8     ------> USART3_TX
     */
     HAL_GPIO_DeInit(USART3_RX_GPIO_Port, USART3_RX_Pin);
 
@@ -251,7 +251,7 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
 
   /* USER CODE END USART3_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -21,5 +21,5 @@ SRC += libs/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
 $(ASMDIR)/libs/%.s: $(SRCDIR)/libs/%.c
 	$(VECHO) "Compiling $<"
 	@$(MKDIR_P) $(@D) $(subst asm,dep,$(@D))
-	$(CC) $(CFLAGS) -Wno-unused-parameter $(MFLAGS) -MD -MP -x c $(INCLUDES) -S $< -o $@
+	$(CC) $(CFLAGS) -w $(MFLAGS) -MD -MP -x c $(INCLUDES) -S $< -o $@
 	@mv $(subst .s,.d,$@) $(subst asm,dep,$(subst .s,.d,$@))

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,10 @@ void main(void)
 	MX_TIM10_Init();
 	MX_TIM12_Init();
 
+	HAL_TIM_Base_Start_IT(&htim7);
+
+	HAL_GPIO_WritePin(GPIOD,GPIO_PIN_15, GPIO_PIN_SET);
+
 	/* Call init function for freertos objects (in freertos.c) */
 	MX_FREERTOS_Init();
 

--- a/src/tasks/task_blinky_led.c
+++ b/src/tasks/task_blinky_led.c
@@ -5,12 +5,66 @@ task_arguments_t task_blinky_led_arguments;
 
 void task_blinky_led_run(task_arguments_t* argv){
 	debug("task_blinky_led run method ");
-	while(1){
-		osDelay(1000);
-		HAL_GPIO_TogglePin(GPIOD, GPIO_PIN_13);
+//	debug("task_blinky_led run method ");
+//	while(1){
+		osDelay(200);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		rotate_for_cmd(30);
+//		osDelay(5000);
+		info("done");
+		HAL_GPIO_TogglePin(GPIOD, GPIO_PIN_14);
 		debug("task_blinky_led run method ");
-	}
-	argv->state = TASK_DONE;
+
+//	}
+//	argv->state = TASK_DONE;
 
 }
 void task_blinky_led_init(task_arguments_t* argv){
@@ -36,7 +90,7 @@ void blinky_led_test(void){
 	strncpy(task_blinky_led.task_name,"Test Task 1\0",12);
 
 	task_blinky_led_arguments.estimated_time = 50;
-	task_blinky_led_arguments.priority = 100;
+	task_blinky_led_arguments.priority = 200;
 	task_blinky_led_arguments.state = TASK_READY;
 
 	task_blinky_led.data = &task_blinky_led_arguments;

--- a/src/tasks/task_blinky_led.h
+++ b/src/tasks/task_blinky_led.h
@@ -2,6 +2,7 @@
 #define TASKS_TASK_BLINKY_LED_H
 
 #include "../core/task_mngr.h"
+#include "../executors/motion/motion_command.h"
 #include "cmsis_os.h"
 
 void blinky_led_test(void);

--- a/src/tasks/task_test_1.h
+++ b/src/tasks/task_test_1.h
@@ -3,6 +3,8 @@
 
 #include "../core/task_mngr.h"
 
+#include "cmsis_os.h"
+
 void ctor_test_1(void);
 
 #endif

--- a/src/tasks/task_test_2.h
+++ b/src/tasks/task_test_2.h
@@ -3,6 +3,8 @@
 
 #include "../core/task_mngr.h"
 
+#include "cmsis_os.h"
+
 void ctor_test_2(void);
 
 #endif

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -1,5 +1,5 @@
 #include "logger.h"
-#include "cmsis_os.h"
+
 
 typedef struct log_one_t {
 	char text[LOGGER_BUFFER_ONE_LOG_SIZE];
@@ -51,7 +51,7 @@ int print_header(void){
 		return 0;
 	}else{
 		char error_mssg[35] = "ERROR LOGGER, CANT GET MUTEX!!!\n";
-		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 1);
+		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 32);
 
 		return -1;
 	}
@@ -82,7 +82,7 @@ int error(const char* format, ...){
 		return 0;
 	}else{
 		char error_mssg[35] = "ERROR LOGGER, CANT GET MUTEX!!!\n";
-		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 1);
+		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 32);
 
 		return -1;
 	}
@@ -114,7 +114,7 @@ int debug(const char* format, ...){
 		return 0;
 	}else{
 		char error_mssg[35] = "ERROR LOGGER, CANT GET MUTEX!!!\n";
-		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 1);
+		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 32);
 
 		return -1;
 	}
@@ -146,7 +146,7 @@ int info(const char* format, ...){
 		return 0;
 	}else{
 		char error_mssg[35] = "ERROR LOGGER, CANT GET MUTEX!!!\n";
-		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 1);
+		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 32, 32);
 
 		return -1;
 	}
@@ -158,8 +158,9 @@ void logger_main(void){
 	if (osMutexWait(rw_mutex,LOGGER_MUTEX_WAIT_MS) == osOK){
 
 		for(int i = 0; i < logs.size; i++){
-			logs.buffer[i].text[++(logs.buffer[i].size)] = '\n';
-			HAL_UART_Transmit(&LOGGER_UART_PORT, (unsigned char *)logs.buffer[i].text, logs.buffer[i].size+1,logs.buffer[i].size);
+			int s = logs.buffer[i].size++;
+			logs.buffer[i].text[s++] = '\n';
+			HAL_UART_Transmit(&LOGGER_UART_PORT, (unsigned char *)logs.buffer[i].text, s, s);
 		}
 
 		logs.size = 0;
@@ -180,7 +181,7 @@ void logger_ctor(void){
 
 	if(rw_mutex == NULL){
 		char error_mssg[35] = "ERROR LOGGER, CANT CREATE MUTEX!!!\n";
-		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 35, 1);
+		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 35, 32);
 	}else{
 		//		char error_mssg[50] = "MUTEX CREATED\n";
 		//		HAL_UART_Transmit(&huart3, (unsigned char *)error_mssg, 20, 1);

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -5,15 +5,16 @@
 #include <stdio.h>
 #include <usart.h>
 #include <string.h>
+#include "cmsis_os.h"
 
-#define LOGGER_BUFFER_LOGS_SIZE 20 ///< size of "string" buffer
+#define LOGGER_BUFFER_LOGS_SIZE 200 ///< size of "string" buffer
 #define LOGGER_BUFFER_ONE_LOG_SIZE 512 ///< size of one log "string"
 
 #define LOGGER_ERROR ///< if LOGGER_ERROR is defined logger will log error logs (log = send data to debug UART port)
 #define LOGGER_INFO  ///< if LOGGER_ERROR is defined logger will log info logs (log = send data to debug UART port)
 #define LOGGER_DEBUG ///< if LOGGER_ERROR is defined logger will log debug logs (log = send data to debug UART port)
 #define LOGGER_UART_PORT huart3 ///< UART port for logging
-#define LOGGER_MUTEX_WAIT_MS 2 ///< wait time of read write mutex to logs
+#define LOGGER_MUTEX_WAIT_MS 5 ///< wait time of read write mutex to logs
 
 #define HEADER_DEBUG_TEXT "\x1B[0m [D] "
 #define HEADER_DEBUG_SIZE 9


### PR DESCRIPTION
Fix motion executor mutex.

Yield thread after mutex release.

Dynamicly allocate motion command structs.
Deallocate memory after pulling the struct out of queue.

Yield after execute task.

bugfix: hal uart send timeout set to good value

Timer resolution dropped by a factor of 10.
No reason to waste a lot of cpu time on unnecessary precsion.

Push the motion command struct point in queue, not its address.

UART4 bautrate 57600

Timer config fixed

qtcreator files ignored

bugfix: sending P to motion driver
To refresh motion driver data, P should be sent instead of S.

enabled TIM7 interrupt

Getting status and position now works.
Coordinates are signed and TIM7 should fire every 10ms.

Motion status is the first byte, but the ascii value doesn't correspond
to enum value, so a switch/case is needed.

TIM7 only sets a flag that motion driver data refresh is needed.
If it were kept the way it was, it make the controller stay in the
interrupt and stops working all together.

FreeRTOS 'bugfix', commented asserts.

Bugfix: added free after tryng to push command to full queue, removed delays.

Added checking if return of vPortMalloc is not NULL.

Added logger thread to execution.

Added debug print, removed delays.

Added blue led at start of application.

Removed while loop.

Implement enemy detection and fix logical bugs in motion executor.