### PR TITLE
Allow disabling of debug()

### DIFF
--- a/make_def_vars.mk
+++ b/make_def_vars.mk
@@ -22,7 +22,7 @@ else
 endif
 
 ifeq ($(DEBUG),0)
-	CFLAGS := -Ofast -Wall -Wextra -Wno-main -std=c11 -fdata-sections -ffunction-sections -fuse-ld=gold
+	CFLAGS := -Ofast -Wall -Wextra -Wno-main -std=c11 -fdata-sections -ffunction-sections -fuse-ld=gold -DNDEBUG
 else
 	CFLAGS := -Og -g -Wall -Wextra -Wno-main -std=c11 -fdata-sections -ffunction-sections -fuse-ld=gold
 endif

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -12,7 +12,10 @@
 
 #define LOGGER_ERROR ///< if LOGGER_ERROR is defined logger will log error logs (log = send data to debug UART port)
 #define LOGGER_INFO  ///< if LOGGER_ERROR is defined logger will log info logs (log = send data to debug UART port)
-#define LOGGER_DEBUG ///< if LOGGER_ERROR is defined logger will log debug logs (log = send data to debug UART port)
+#ifndef NDEBUG
+	#define LOGGER_DEBUG ///< if LOGGER_ERROR is defined logger will log debug logs (log = send data to debug UART port)
+#define NDEBUG
+#endif /* ifndef NDEBUG */
 #define LOGGER_UART_PORT huart3 ///< UART port for logging
 #define LOGGER_MUTEX_WAIT_MS 5 ///< wait time of read write mutex to logs
 


### PR DESCRIPTION
This make `debug()` from `logger.c` an empty function if `NDEBUG` is defined.